### PR TITLE
macOS (Darwin) compatibility patch

### DIFF
--- a/libraries/pallas/include/pallas/pallas.h
+++ b/libraries/pallas/include/pallas/pallas.h
@@ -363,7 +363,7 @@ public:
 typedef struct Loop {
   Token repeated_token;               /**< Token of the Sequence being repeated. */
   Token self_id;                      /**< Token identifying that Loop. */
-  uint nb_iterations;                 /**< Number of iterations of that loop. */
+  unsigned int nb_iterations;         /**< Number of iterations of that loop. */
 #ifdef __cplusplus
   CXX(void addIteration();)           /**< Adds an iteration to the lastest occurence of that loop. */
 

--- a/libraries/pallas/include/pallas/pallas_log.h
+++ b/libraries/pallas/include/pallas/pallas_log.h
@@ -5,7 +5,7 @@
 #pragma once
 #include <inttypes.h>
 #include <stddef.h>
-extern __thread size_t thread_rank;
+extern __thread uint64_t thread_rank;
 extern unsigned int pallas_mpi_rank;
 
 /** Stops the execution. */

--- a/libraries/pallas/include/pallas/pthread_barrier_wrapper.h
+++ b/libraries/pallas/include/pallas/pthread_barrier_wrapper.h
@@ -1,0 +1,76 @@
+#ifndef PTHREAD_BARRIER_WRAPPER_H
+#define PTHREAD_BARRIER_WRAPPER_H
+
+// Wrapper of pthread barrier functionality for improved
+// portability on non-linux systems -- Aaron
+
+#include <pthread.h>
+
+// Detect compilation on Darwin (i.e. macos) target
+#if defined(__APPLE__)
+    #define NEED_PTHREAD_BARRIER_FALLBACK
+#endif
+
+#ifdef NEED_PTHREAD_BARRIER_FALLBACK
+
+#ifndef PTHREAD_BARRIER_SERIAL_THREAD
+// Default value: -1
+#define PTHREAD_BARRIER_SERIAL_THREAD (-1)
+#endif
+
+typedef struct {
+    pthread_mutex_t mutex;
+    pthread_cond_t condition_var;
+    unsigned int threads_required;       // required number of threads at barrier
+    unsigned int threads_remaining;      // number of threads yet to reach barrier
+    unsigned int generation;             // 
+} pthread_barrier_t;
+
+static inline int pthread_barrier_init(pthread_barrier_t *barrier,
+                                       void *attr, // unused pthread_barrierattr_t
+                                       unsigned int count) {
+    pthread_mutex_init(&barrier->mutex, NULL);
+    pthread_cond_init(&barrier->condition_var, NULL);
+    barrier->threads_required = count;
+    barrier->threads_remaining = count;
+    barrier->generation = 0;
+    return 0;
+}
+
+static inline int pthread_barrier_destroy(pthread_barrier_t *barrier) {
+    pthread_mutex_destroy(&barrier->mutex);
+    pthread_cond_destroy(&barrier->condition_var);
+    return 0;
+}
+
+static inline int pthread_barrier_wait(pthread_barrier_t *barrier) {
+
+    pthread_mutex_lock(&barrier->mutex);
+
+    if (--(barrier->threads_remaining) == 0) {
+        barrier->generation++;
+        barrier->threads_remaining = barrier->threads_required;
+
+        pthread_cond_broadcast(&barrier->condition_var);
+        pthread_mutex_unlock(&barrier->mutex);
+        return PTHREAD_BARRIER_SERIAL_THREAD;
+    } else {
+      unsigned int gen = barrier->generation;
+
+      while (gen == barrier->generation) {
+          pthread_cond_wait(&barrier->condition_var, &barrier->mutex);
+      }
+
+      pthread_mutex_unlock(&barrier->mutex);
+      return 0;
+    }
+}
+
+#else // NEED_PTHREAD_BARRIER_FALLBACK
+
+  // I.e. Linux compilation target
+  // No implementation necessary, included in pthread.h
+
+#endif // NEED_PTHREAD_BARRIER_FALLBACK
+
+#endif // PTHREAD_BARRIER_WRAPPER_H

--- a/libraries/pallas/include/pallas/pthread_barrier_wrapper.h
+++ b/libraries/pallas/include/pallas/pthread_barrier_wrapper.h
@@ -2,7 +2,7 @@
 #define PTHREAD_BARRIER_WRAPPER_H
 
 // Wrapper of pthread barrier functionality for improved
-// portability on non-linux systems -- Aaron
+// portability on non-linux systems
 
 #include <pthread.h>
 

--- a/test/mpi/mpi_benchmark.c
+++ b/test/mpi/mpi_benchmark.c
@@ -12,6 +12,7 @@
 #include "pallas/pallas_archive.h"
 #include "pallas/pallas_record.h"
 #include "pallas/pallas_write.h"
+#include "pallas/pthread_barrier_wrapper.h"
 
 static GlobalArchive * trace = NULL;
 static Archive * archive = NULL;

--- a/test/test_hash.cpp
+++ b/test/test_hash.cpp
@@ -4,7 +4,7 @@
  */
 
 #include <inttypes.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include "pallas/pallas_hash.h"
 #include "pallas/pallas_log.h"
 

--- a/test/write_benchmark.c
+++ b/test/write_benchmark.c
@@ -10,6 +10,7 @@
 #include "pallas/pallas_archive.h"
 #include "pallas/pallas_write.h"
 #include "pallas/pallas_record.h"
+#include "pallas/pthread_barrier_wrapper.h"
 
 
 static struct GlobalArchive* trace = NULL;

--- a/test/write_benchmark.cpp
+++ b/test/write_benchmark.cpp
@@ -17,6 +17,7 @@
 #include "pallas/pallas_record.h"
 #include "pallas/pallas_write.h"
 #include "pallas/pallas_log.h"
+#include "pallas/pthread_barrier_wrapper.h"
 
 using namespace pallas;
 static LocationGroupId processID;


### PR DESCRIPTION
This PR should include all the necessary changes (along with those already committed to main) to make pallas buildable on an aarch64 macOS target machine. Most notable is the addition of my pthread wrapper (pthread_barrier_wrapper.h). I put this file in the pallas libraries includes folder but you may want to move it as it only applies to the test src files.